### PR TITLE
feat: make blocking_workers configurable

### DIFF
--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -70,6 +70,8 @@ pub struct Config {
     pub port: u16,
     /// Number of threads to use for executing futures. **(default: `num_cores`)**
     pub workers: usize,
+    /// Number of threads to use for executing blocking futures. **(default: `512`)**
+    pub blocking_workers: usize,
     /// How, if at all, to identify the server via the `Server` header.
     /// **(default: `"Rocket"`)**
     pub ident: Ident,
@@ -167,6 +169,7 @@ impl Config {
             address: Ipv4Addr::new(127, 0, 0, 1).into(),
             port: 8000,
             workers: num_cpus::get(),
+            blocking_workers: 512,
             ident: Ident::default(),
             limits: Limits::default(),
             temp_dir: std::env::temp_dir().into(),
@@ -355,6 +358,7 @@ impl Config {
         launch_info_!("address: {}", bold(&self.address));
         launch_info_!("port: {}", bold(&self.port));
         launch_info_!("workers: {}", bold(self.workers));
+        launch_info_!("blocking_workers: {}", bold(self.blocking_workers));
         launch_info_!("ident: {}", bold(&self.ident));
         launch_info_!("limits: {}", bold(&self.limits));
         launch_info_!("temp dir: {}", bold(&self.temp_dir.relative().display()));
@@ -446,6 +450,9 @@ impl Config {
 
     /// The stringy parameter name for setting/extracting [`Config::workers`].
     pub const WORKERS: &'static str = "workers";
+
+    /// The stringy parameter name for setting/extracting [`Config::blocking_workers`].
+    pub const BLOCKING_WORKERS: &'static str = "blocking_workers";
 
     /// The stringy parameter name for setting/extracting [`Config::keep_alive`].
     pub const KEEP_ALIVE: &'static str = "keep_alive";

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -232,6 +232,7 @@ pub fn async_main<R>(fut: impl std::future::Future<Output = R> + Send) -> R {
     // See tokio-rs/tokio#3329 for a necessary solution in `tokio`.
     tokio::runtime::Builder::new_multi_thread()
         .worker_threads(Config::from(Config::figment()).workers)
+        .max_blocking_threads(Config::from(Config::figment()).blocking_workers)
         // NOTE: graceful shutdown depends on the "rocket-worker" prefix.
         .thread_name("rocket-worker-thread")
         .enable_all()

--- a/site/guide/9-configuration.md
+++ b/site/guide/9-configuration.md
@@ -17,21 +17,22 @@ is configured with. This means that no matter which configuration provider
 Rocket is asked to use, it must be able to read the following configuration
 values:
 
-| key            | kind              | description                                     | debug/release default   |
-|----------------|-------------------|-------------------------------------------------|-------------------------|
-| `address`      | `IpAddr`          | IP address to serve on                          | `127.0.0.1`             |
-| `port`         | `u16`             | Port to serve on.                               | `8000`                  |
-| `workers`      | `usize`           | Number of threads to use for executing futures. | cpu core count          |
-| `ident`        | `string`, `false` | If and how to identify via the `Server` header. | `"Rocket"`              |
-| `keep_alive`   | `u32`             | Keep-alive timeout seconds; disabled when `0`.  | `5`                     |
-| `log_level`    | [`LogLevel`]      | Max level to log. (off/normal/debug/critical)   | `normal`/`critical`     |
-| `cli_colors`   | `bool`            | Whether to use colors and emoji when logging.   | `true`                  |
-| `secret_key`   | [`SecretKey`]     | Secret key for signing and encrypting values.   | `None`                  |
-| `tls`          | [`TlsConfig`]     | TLS configuration, if any.                      | `None`                  |
-| `limits`       | [`Limits`]        | Streaming read size limits.                     | [`Limits::default()`]   |
-| `limits.$name` | `&str`/`uint`     | Read limit for `$name`.                         | forms = "32KiB"         |
-| `ctrlc`        | `bool`            | Whether `ctrl-c` initiates a server shutdown.   | `true`                  |
-| `shutdown`     | [`Shutdown`]      | Graceful shutdown configuration.                | [`Shutdown::default()`] |
+| key                     | kind              | description                                              | debug/release default   |
+|-------------------------|-------------------|----------------------------------------------------------|-------------------------|
+| `address`               | `IpAddr`          | IP address to serve on                                   | `127.0.0.1`             |
+| `port`                  | `u16`             | Port to serve on.                                        | `8000`                  |
+| `workers`               | `usize`           | Number of threads to use for executing futures.          | cpu core count          |
+| `blocking_workers`      | `usize`           | Number of threads to use for executing blocking futures. | 512                     |
+| `ident`                 | `string`, `false` | If and how to identify via the `Server` header.          | `"Rocket"`              |
+| `keep_alive`            | `u32`             | Keep-alive timeout seconds; disabled when `0`.           | `5`                     |
+| `log_level`             | [`LogLevel`]      | Max level to log. (off/normal/debug/critical)            | `normal`/`critical`     |
+| `cli_colors`            | `bool`            | Whether to use colors and emoji when logging.            | `true`                  |
+| `secret_key`            | [`SecretKey`]     | Secret key for signing and encrypting values.            | `None`                  |
+| `tls`                   | [`TlsConfig`]     | TLS configuration, if any.                               | `None`                  |
+| `limits`                | [`Limits`]        | Streaming read size limits.                              | [`Limits::default()`]   |
+| `limits.$name`          | `&str`/`uint`     | Read limit for `$name`.                                  | forms = "32KiB"         |
+| `ctrlc`                 | `bool`            | Whether `ctrl-c` initiates a server shutdown.            | `true`                  |
+| `shutdown`              | [`Shutdown`]      | Graceful shutdown configuration.                         | [`Shutdown::default()`] |
 
 ### Profiles
 
@@ -135,6 +136,7 @@ sensible.
 address = "127.0.0.1"
 port = 8000
 workers = 16
+blocking_workers = 512
 keep_alive = 5
 ident = "Rocket"
 log_level = "normal"
@@ -337,6 +339,15 @@ configuration value cannot be reconfigured or be configured from sources other
 than those provided by [`Config::figment()`]. In other words, only the values
 set by the `ROCKET_WORKERS` environment variable or in the `workers` property of
 `Rocket.toml` will be considered - all other `workers` values are ignored.
+
+The `blocking_workers` parameter sets the maximum number of threads tokio will
+spawn to execute futures spawned with `spawn_blocking`. Similar to the `workers`
+parameter, this cannot be reconfigured. The runtime will only spawn these threads
+if there are futures to execute on them, and leaving this at it's default value
+is generally prefered. Rocket rarely spawns any of these, so running into the limit
+is unlikely, although in some situations the OS will limit the number of threads
+Rocket can spawn. In these situations, either the OS limit needs to be raised or
+the Rocket limit needs to be lowered.
 
 ## Extracting Values
 


### PR DESCRIPTION
Thx to @the10thWiz
https://github.com/SergioBenitez/Rocket/pull/2064

Mostly a topic with bad app architecture when worker threads are running too long or block and workers are as a result of exhausted.  
Results in a panic: https://github.com/SergioBenitez/Rocket/issues/2031
```
thread 'rocket-worker-thread' panicked at 'called `Result::unwrap()` on an `Err` value: PoisonError { .. }', 
/root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/blocking/pool.rs:287:86
```
But on limited OS configurations this needs to be adapted to the OS capabilities.

The default of tokio runtime max_blocking_threads is 512 and becomes modified by this config. 

