### PR TITLE
fix(docs): url to owasp.org path traversal doc

### DIFF
--- a/site/guide/4-requests.md
+++ b/site/guide/4-requests.md
@@ -149,7 +149,7 @@ async fn files(file: PathBuf) -> Option<NamedFile> {
 }
 ```
 
-[path traversal attacks]: https://www.owasp.org/index.php/Path_Traversal
+[path traversal attacks]: https://owasp.org/www-community/attacks/Path_Traversal
 
 ! tip: Rocket makes it even _easier_ to serve static files!
 


### PR DESCRIPTION
The url to owasp.org doc has changed.

thx @xypnox
https://github.com/SergioBenitez/Rocket/pull/1920