### PR TITLE
fix: `launch_info!` should be logged with info level

### DIFF
--- a/core/lib/src/log.rs
+++ b/core/lib/src/log.rs
@@ -32,8 +32,8 @@ define_log_macro!(warn, warn_);
 define_log_macro!(info, info_);
 define_log_macro!(debug, debug_);
 define_log_macro!(trace, trace_);
-define_log_macro!(launch_info: warn, "rocket::launch", $);
-define_log_macro!(launch_info_: warn, "rocket::launch_", $);
+define_log_macro!(launch_info: info, "rocket::launch", $);
+define_log_macro!(launch_info_: info, "rocket::launch_", $);
 
 #[derive(Debug)]
 struct RocketLogger;


### PR DESCRIPTION
Checked every usage of `launch_info!` and all should be info level.

thx @davidv1992 
https://github.com/SergioBenitez/Rocket/pull/1912
Fixes https://github.com/SergioBenitez/Rocket/issues/1828