### PR TITLE
fix(msgpack): use `msgpack::to_vec()` not `rmp_serde::to_vec()`

### DIFF
--- a/core/lib/src/serde/msgpack.rs
+++ b/core/lib/src/serde/msgpack.rs
@@ -188,7 +188,7 @@ impl<'r, T: Deserialize<'r>> FromData<'r> for MsgPack<T> {
 /// serialization fails, an `Err` of `Status::InternalServerError` is returned.
 impl<'r, T: Serialize> Responder<'r, 'static> for MsgPack<T> {
     fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
-        let buf = rmp_serde::to_vec(&self.0)
+        let buf = to_vec(&self.0)
             .map_err(|e| {
                 error_!("MsgPack failed to serialize: {:?}", e);
                 Status::InternalServerError


### PR DESCRIPTION
`rmp_serde::to_vec()` is compact MsgPack form.
Here might be intended to provide by default the named form,
so own `msgpack::to_vec()`.

thx @Lochlanna
https://github.com/SergioBenitez/Rocket/pull/1882